### PR TITLE
add flag to disable automatic pageview tracking

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -34,6 +34,7 @@ FacebookPixel.prototype.initialize = function(){
   };
   window.fbq.push = window.fbq;
   window.fbq.loaded = true;
+  window.fbq.disablePushState = true; // disables automatic pageview tracking
   window.fbq.agent = 'seg';
   window.fbq.version = '2.0';
   window.fbq.queue = [];

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -35,6 +35,7 @@ describe('Facebook Pixel', function() {
   describe('before loading', function() {
     beforeEach(function() {
       analytics.stub(facebookPixel, 'load');
+      analytics.initialize();
     });
 
     afterEach(function() {
@@ -42,14 +43,22 @@ describe('Facebook Pixel', function() {
     });
 
     describe('#initialize', function() {
-      it('should load on initialize', function() {
-        analytics.initialize();
+      it('should call load on initialize', function() {
         analytics.called(facebookPixel.load);
       });
-    });
 
-    describe('#loaded', function() {
+      it('should set the correct agent and version', function() {
+        analytics.equal(window.fbq.agent, 'seg');
+        analytics.equal(window.fbq.version, '2.0');
+      });
 
+      it('should set disablePushState to true', function() {
+        analytics.equal(window.fbq.disablePushState, true);
+      });
+
+      it('should create fbq object', function() {
+        analytics.assert(window.fbq instanceof Function);
+      });
     });
   });
 


### PR DESCRIPTION
This fixes #5.

This is undocumented use of FB's lib but looking at the code regarding how they handle the automatic pageview tracking, setting `disableStatePush` to `true` will prevent their library triggering its own page views -- that should only happen when our `.page()` call is invoked.

This is FB's logic for automatic pageview tracking:

```js
(function ca() {
      if (j.disablePushState === true)
        return;
      if (!d.pushState || !d.replaceState)
        return;
      var da = function() {
        s = m;
        m = c.href;
        if (m === s)
          return;
        var ea = new v({
          allowDuplicatePageViews: true
        });
        j.trackWithoutValidation.call(ea, 'PageView');
      }
      ;
      h.injectMethod(d, 'pushState', da);
      h.injectMethod(d, 'replaceState', da);
      a.addEventListener('popstate', da, false);
    })();
```

Also there was an empty `#loaded` test `describe` block so I removed that and added some additional tests that checks for proper initialization. 

@sperand-io @segment-integrations/core 