### PR TITLE
update ecommerce spec syntax to v2

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -120,13 +120,13 @@ FacebookPixel.prototype.track = function(track) {
 };
 
 /**
- * Viewed product category.
+ * Product List Viewed.
  *
  * @api private
  * @param {Track} track category
  */
 
-FacebookPixel.prototype.viewedProductCategory = function(track) {
+FacebookPixel.prototype.productListViewed = function(track) {
   window.fbq('track', 'ViewContent', {
     content_ids: [track.category() || ''],
     content_type: 'product_group'
@@ -142,13 +142,13 @@ FacebookPixel.prototype.viewedProductCategory = function(track) {
 };
 
 /**
- * Viewed product.
+ * Product viewed.
  *
  * @api private
  * @param {Track} track
  */
 
-FacebookPixel.prototype.viewedProduct = function(track) {
+FacebookPixel.prototype.productViewed = function(track) {
   window.fbq('track', 'ViewContent', {
     content_ids: [track.id() || track.sku() || ''],
     content_type: 'product',
@@ -168,13 +168,13 @@ FacebookPixel.prototype.viewedProduct = function(track) {
 };
 
 /**
- * Added product.
+ * Product added.
  *
  * @api private
  * @param {Track} track
  */
 
-FacebookPixel.prototype.addedProduct = function(track) {
+FacebookPixel.prototype.productAdded = function(track) {
   window.fbq('track', 'AddToCart', {
     content_ids: [track.id() || track.sku() || ''],
     content_type: 'product',
@@ -194,13 +194,13 @@ FacebookPixel.prototype.addedProduct = function(track) {
 };
 
 /**
- * Completed Order.
+ * Order Completed.
  *
  * @api private
  * @param {Track} track
  */
 
-FacebookPixel.prototype.completedOrder = function(track) {
+FacebookPixel.prototype.orderCompleted = function(track) {
   var key;
   var content_ids = foldl(function(acc, product) {
     key = product.id || product.sku;

--- a/package.json
+++ b/package.json
@@ -25,13 +25,13 @@
   "dependencies": {
     "@ndhoule/each": "^2.0.1",
     "@ndhoule/foldl": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0",
+    "@segment/analytics.js-integration": "^3.0.0",
     "moment": "^2.14.1",
     "reject": "0.0.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",
-    "@segment/analytics.js-integration-tester": "^2.0.0",
+    "@segment/analytics.js-integration-tester": "^3.0.0",
     "@segment/clear-env": "^2.0.0",
     "@segment/eslint-config": "^3.1.1",
     "browserify": "^13.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -196,16 +196,16 @@ describe('Facebook Pixel', function() {
       });
 
       describe('segment ecommerce => FB product audiences', function() {
-        it('Viewed Product Category', function() {
-          analytics.track('Viewed Product Category', { category: 'Games' });
+        it('Product List Viewed', function() {
+          analytics.track('Product List Viewed', { category: 'Games' });
           analytics.called(window.fbq, 'track', 'ViewContent', {
             content_ids: ['Games'],
             content_type: 'product_group'
           });
         });
 
-        it('Viewed Product', function() {
-          analytics.track('Viewed Product', {
+        it('Product Viewed', function() {
+          analytics.track('Product Viewed', {
             id: '507f1f77bcf86cd799439011',
             currency: 'USD',
             quantity: 1,
@@ -225,7 +225,7 @@ describe('Facebook Pixel', function() {
         });
 
         it('Adding to Cart', function() {
-          analytics.track('Added Product', {
+          analytics.track('Product Added', {
             id: '507f1f77bcf86cd799439011',
             currency: 'USD',
             quantity: 1,
@@ -245,7 +245,7 @@ describe('Facebook Pixel', function() {
         });
 
         it('Completing an Order', function() {
-          analytics.track('Completed Order', {
+          analytics.track('Order Completed', {
             products: [
               { id: '507f1f77bcf86cd799439011' },
               { id: '505bd76785ebb509fc183733' }


### PR DESCRIPTION
This PR changes the ecommerce V1 syntax Action + Object to the new V2 syntax, Object + Action.

This PR will be waiting on a few blockers, a refactor of the Analytics-Events repo to be more concise and readable as we add more events to our spec and for similar changes to be made to all other integrations currently using V1 syntax.

Tests are failing because it isn't properly aliasing against the new spec'd events. These tests will need to pass, dependent on a new version of Analytics Events and Analytics.js-Private before being merged.