### PR TITLE
Add/advanced matching

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -29,13 +29,14 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
  */
 
 FacebookPixel.prototype.initialize = function() {
-  window.fbq = window._fbq = function() {
+  window._fbq = function() {
     if (window.fbq.callMethod) {
       window.fbq.callMethod.apply(window.fbq, arguments);
     } else {
       window.fbq.queue.push(arguments);
     }
   };
+  window.fbq = window.fbq || window._fbq;
   window.fbq.push = window.fbq;
   window.fbq.loaded = true;
   window.fbq.disablePushState = true; // disables automatic pageview tracking
@@ -44,7 +45,6 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.queue = [];
   this.load(this.ready);
   var traits = formatTraits(this.analytics);
-
   window.fbq(
     'init',
     this.options.pixelId,

--- a/lib/index.js
+++ b/lib/index.js
@@ -36,6 +36,7 @@ FacebookPixel.prototype.initialize = function() {
       window.fbq.queue.push(arguments);
     }
   };
+
   window.fbq = window.fbq || window._fbq;
   window.fbq.push = window.fbq;
   window.fbq.loaded = true;
@@ -248,7 +249,18 @@ function formatRevenue(revenue) {
 function formatTraits(analytics) {
   var traits = analytics && analytics.user().traits();
   if (!traits) return {};
-  var nameArray = traits.name && traits.name.toLowerCase().split(' ') || [];
+  var firstName;
+  var lastName;
+  // Check for firstName property
+  // else check for name
+  if (traits.firstName) {
+    firstName = traits.firstName;
+    lastName = traits.lastName;
+  } else {
+    var nameArray = traits.name && traits.name.toLowerCase().split(' ') || [];
+    firstName = nameArray.shift();
+    lastName = nameArray.pop();
+  }
   var gender = traits.gender && traits.gender.slice(0,1).toLowerCase();
   var birthday = traits.birthday && moment(traits.birthday).format('YYYYMMDD');
   
@@ -258,8 +270,8 @@ function formatTraits(analytics) {
   var postalCode = address.postalCode;
   return reject({
     em: traits.email,
-    fn: nameArray.shift(),
-    ln: nameArray.pop(),
+    fn: firstName,
+    ln: lastName,
     ph: traits.phone,
     ge: gender,
     db: birthday,

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,8 @@
 var integration = require('@segment/analytics.js-integration');
 var foldl = require('@ndhoule/foldl');
 var each = require('@ndhoule/each');
+var reject = require('reject');
+var moment = require('moment');
 
 /**
  * Expose `Facebook Pixel`.
@@ -41,7 +43,13 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.version = '2.0';
   window.fbq.queue = [];
   this.load(this.ready);
-  window.fbq('init', this.options.pixelId);
+  var traits = formatTraits(this.analytics);
+
+  window.fbq(
+    'init',
+    this.options.pixelId,
+    traits
+  );
 };
 
 /**
@@ -227,4 +235,36 @@ FacebookPixel.prototype.completedOrder = function(track) {
 
 function formatRevenue(revenue) {
   return Number(revenue || 0).toFixed(2);
+}
+
+/**
+ * Get Traits Formatted Correctly for FB.
+ * 
+ * https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match
+ * 
+ * @api private
+ */
+
+function formatTraits(analytics) {
+  var traits = analytics && analytics.user().traits();
+  if (!traits) return {};
+  var nameArray = traits.name && traits.name.toLowerCase().split(' ') || [];
+  var gender = traits.gender && traits.gender.slice(0,1).toLowerCase();
+  var birthday = traits.birthday && moment(traits.birthday).format('YYYYMMDD');
+  
+  var address = traits.address || {};
+  var city = address.city && address.city.split(' ').join('').toLowerCase();
+  var state = address.state && address.state.toLowerCase();
+  var postalCode = address.postalCode;
+  return reject({
+    em: traits.email,
+    fn: nameArray.shift(),
+    ln: nameArray.pop(),
+    ph: traits.phone,
+    ge: gender,
+    db: birthday,
+    ct: city,
+    st: state,
+    zp: postalCode
+  });
 }

--- a/package.json
+++ b/package.json
@@ -25,7 +25,9 @@
   "dependencies": {
     "@ndhoule/each": "^2.0.1",
     "@ndhoule/foldl": "^2.0.1",
-    "@segment/analytics.js-integration": "^2.1.0"
+    "@segment/analytics.js-integration": "^2.1.0",
+    "moment": "^2.14.1",
+    "reject": "0.0.1"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -26,13 +26,13 @@ describe('Facebook Pixel', function() {
     analytics.use(tester);
     analytics.add(facebookPixel);
     analytics.identify('123', {
-      'name': 'Ash Ketchum',
-      'gender': 'Male',
-      'birthday': '01/13/1991',
-      'address': {
-        'city': 'Emerald',
-        'state': 'Kanto',
-        'postalCode': 123456
+      name: 'Ash Ketchum',
+      gender: 'Male',
+      birthday: '01/13/1991',
+      address: {
+        city: 'Emerald',
+        state: 'Kanto',
+        postalCode: 123456
       }
     });
   });
@@ -85,21 +85,18 @@ describe('Facebook Pixel', function() {
     });
 
     it('should call init with the user\'s traits', function() {
-      // proving that fbq has been stubbed
-      console.log(window.fbq);
-      // Expected stub to have been called?
       analytics.called(
         window.fbq,
         'init',
         options.pixelId,
         {
-          'ct': 'emerald',
-          'db': '19910113',
-          'fn': 'ash',
-          'ge': 'm',
-          'ln': 'ketchum',
-          'st': 'kanto',
-          'zp': 123456
+          ct: 'emerald',
+          db: '19910113',
+          fn: 'ash',
+          ge: 'm',
+          ln: 'ketchum',
+          st: 'kanto',
+          zp: 123456
         }
       );
     });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -25,6 +25,16 @@ describe('Facebook Pixel', function() {
     analytics.use(FacebookPixel);
     analytics.use(tester);
     analytics.add(facebookPixel);
+    analytics.identify('123', {
+      'name': 'Ash Ketchum',
+      'gender': 'Male',
+      'birthday': '01/13/1991',
+      'address': {
+        'city': 'Emerald',
+        'state': 'Kanto',
+        'postalCode': 123456
+      }
+    });
   });
 
   afterEach(function() {
@@ -65,8 +75,33 @@ describe('Facebook Pixel', function() {
   });
 
   describe('loading', function() {
+    beforeEach(function() {
+      analytics.initialize();
+      analytics.stub(window, 'fbq');
+    });
+
     it('should load', function(done) {
       analytics.load(facebookPixel, done);
+    });
+
+    it('should call init with the user\'s traits', function() {
+      // proving that fbq has been stubbed
+      console.log(window.fbq);
+      // Expected stub to have been called?
+      analytics.called(
+        window.fbq,
+        'init',
+        options.pixelId,
+        {
+          'ct': 'emerald',
+          'db': '19910113',
+          'fn': 'ash',
+          'ge': 'm',
+          'ln': 'ketchum',
+          'st': 'kanto',
+          'zp': 123456
+        }
+      );
     });
   });
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -76,8 +76,8 @@ describe('Facebook Pixel', function() {
 
   describe('loading', function() {
     beforeEach(function() {
-      analytics.initialize();
       analytics.stub(window, 'fbq');
+      analytics.initialize();
     });
 
     it('should load', function(done) {


### PR DESCRIPTION
This PR adds support for Facebook Advanced Pixel Matching.
https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match

On initialize, we check for a user's traits that have been cached by A.js and fill in any matching attributes that are recognized by Facebook.

I removed the explicit overwriting of window.fbq on every page load so that it would be easier to test and because their snippet returns the existing `fbq` on initialization if window.fbq is already defined. I tested this and saw the pixels firing.