### PR TITLE
gate initialization with traits behind option

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
   .global('fbq')
   .option('pixelId', '')
   .option('agent', 'seg')
+  .option('initWithExistingTraits', false)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
@@ -45,12 +46,12 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.version = '2.0';
   window.fbq.queue = [];
   this.load(this.ready);
-  var traits = formatTraits(this.analytics);
-  window.fbq(
-    'init',
-    this.options.pixelId,
-    traits
-  );
+  if (this.options.initWithExistingTraits) {
+    var traits = formatTraits(this.analytics);
+    window.fbq('init', this.options.pixelId, traits);
+  } else {
+    window.fbq('init', this.options.pixelId);
+  }
 };
 
 /**
@@ -240,9 +241,9 @@ function formatRevenue(revenue) {
 
 /**
  * Get Traits Formatted Correctly for FB.
- * 
+ *
  * https://developers.facebook.com/docs/facebook-pixel/pixel-with-ads/conversion-tracking#advanced_match
- * 
+ *
  * @api private
  */
 
@@ -263,7 +264,6 @@ function formatTraits(analytics) {
   }
   var gender = traits.gender && traits.gender.slice(0,1).toLowerCase();
   var birthday = traits.birthday && moment(traits.birthday).format('YYYYMMDD');
-  
   var address = traits.address || {};
   var city = address.city && address.city.split(' ').join('').toLowerCase();
   var state = address.state && address.state.toLowerCase();

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -16,7 +16,8 @@ describe('Facebook Pixel', function() {
       standardEvent: 'standard'
     },
     pixelId: '123123123',
-    agent: 'test'
+    agent: 'test',
+    initWithExistingTraits: false
   };
 
   beforeEach(function() {
@@ -47,7 +48,6 @@ describe('Facebook Pixel', function() {
   describe('before loading', function() {
     beforeEach(function() {
       analytics.stub(facebookPixel, 'load');
-      analytics.initialize();
     });
 
     afterEach(function() {
@@ -56,20 +56,47 @@ describe('Facebook Pixel', function() {
 
     describe('#initialize', function() {
       it('should call load on initialize', function() {
+        analytics.initialize();
         analytics.called(facebookPixel.load);
       });
 
       it('should set the correct agent and version', function() {
+        analytics.initialize();
         analytics.equal(window.fbq.agent, 'test');
         analytics.equal(window.fbq.version, '2.0');
       });
 
       it('should set disablePushState to true', function() {
+        analytics.initialize();
         analytics.equal(window.fbq.disablePushState, true);
       });
 
       it('should create fbq object', function() {
+        analytics.initialize();
         analytics.assert(window.fbq instanceof Function);
+      });
+
+      before(function() {
+        options.initWithExistingTraits = true; 
+      });
+
+      after(function() {
+        options.initWithExistingTraits = false; 
+      });
+
+      it('should call init with the user\'s traits if option enabled', function() {
+        var payload = {
+          ct: 'emerald',
+          db: '19910113',
+          fn: 'ash',
+          ge: 'm',
+          ln: 'ketchum',
+          st: 'kanto',
+          zp: 123456
+        };
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'init', options.pixelId, payload);
       });
     });
   });
@@ -82,23 +109,6 @@ describe('Facebook Pixel', function() {
 
     it('should load', function(done) {
       analytics.load(facebookPixel, done);
-    });
-
-    it('should call init with the user\'s traits', function() {
-      analytics.called(
-        window.fbq,
-        'init',
-        options.pixelId,
-        {
-          ct: 'emerald',
-          db: '19910113',
-          fn: 'ash',
-          ge: 'm',
-          ln: 'ketchum',
-          st: 'kanto',
-          zp: 123456
-        }
-      );
     });
   });
 


### PR DESCRIPTION
https://segment.atlassian.net/browse/INT-592

This puts the feature introduced in #20 behind an option. This means that people would need to opt in in order to initialize facebook pixel with existing `traits` that's been `.identify()`ed already.

- [ ] docs: https://github.com/segmentio/site-docs/pull/1797
- [ ] update metadata
- [ ] mongo script to set `initWithExistingTraits` to true for all existing user: https://github.com/segmentio/mongo-scripts/pull/209

@thehydroimpulse @wcjohnson11 