### PR TITLE
Switch from moment to dateformat

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,7 +8,7 @@ var integration = require('@segment/analytics.js-integration');
 var foldl = require('@ndhoule/foldl');
 var each = require('@ndhoule/each');
 var reject = require('reject');
-var moment = require('moment');
+var dateformat = require('dateformat');
 
 /**
  * Expose `Facebook Pixel`.
@@ -263,7 +263,7 @@ function formatTraits(analytics) {
     lastName = nameArray.pop();
   }
   var gender = traits.gender && traits.gender.slice(0,1).toLowerCase();
-  var birthday = traits.birthday && moment(traits.birthday).format('YYYYMMDD');
+  var birthday = traits.birthday && dateformat(traits.birthday, 'yyyymmdd');
   var address = traits.address || {};
   var city = address.city && address.city.split(' ').join('').toLowerCase();
   var state = address.state && address.state.toLowerCase();

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "@ndhoule/each": "^2.0.1",
     "@ndhoule/foldl": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
-    "moment": "^2.14.1",
+    "dateformat": "^1.0.12",
     "reject": "0.0.1"
   },
   "devDependencies": {


### PR DESCRIPTION
The `moment` library is around 50kb _minified_, which ends up being around 15% of the total size of `analytics.min.js`. Switch to `dateformat` which has a much smaller footprint.