### PR TITLE
fallback to USD for currency for mapped "Purchase" events

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -106,8 +106,10 @@ FacebookPixel.prototype.track = function(track) {
   }
 
   // standard conversion events, mapped to one of 9 standard events
+  // "Purchase" requires a currency parameter; default to USD
   // send full transformed payload
   each(function(event) {
+    if (event === 'Purchase') payload.currency = payload.currency || 'USD';
     window.fbq('track', event, payload);
   }, standard);
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -13,7 +13,8 @@ describe('Facebook Pixel', function() {
       legacyEvent: 'asdFrkj'
     },
     standardEvents: {
-      standardEvent: 'standard'
+      standardEvent: 'standard',
+      'booking completed': 'Purchase'
     },
     pixelId: '123123123',
     agent: 'test',
@@ -77,11 +78,11 @@ describe('Facebook Pixel', function() {
       });
 
       before(function() {
-        options.initWithExistingTraits = true; 
+        options.initWithExistingTraits = true;
       });
 
       after(function() {
-        options.initWithExistingTraits = false; 
+        options.initWithExistingTraits = false;
       });
 
       it('should call init with the user\'s traits if option enabled', function() {
@@ -199,6 +200,18 @@ describe('Facebook Pixel', function() {
           });
           analytics.called(window.fbq, 'track', 'standard', {
             currency: 'XXX',
+            value: '13.00',
+            property: true
+          });
+        });
+
+        it('should default currency to USD if mapped to "Purchase"', function() {
+          analytics.track('booking completed', {
+            revenue: 13,
+            property: true
+          });
+          analytics.called(window.fbq, 'track', 'Purchase', {
+            currency: 'USD',
             value: '13.00',
             property: true
           });


### PR DESCRIPTION
`currency` is required for *any* "Purchase" event, so if not present in the mapped call we should fallback to `'USD'`

![screenshot_2016-09-13_15 21 29_480](https://cloud.githubusercontent.com/assets/3130232/18493752/fe406a88-79c6-11e6-8cae-3aa0ff01c834.png)

![screenshot_2016-09-13_15 22 57_480](https://cloud.githubusercontent.com/assets/3130232/18493757/04ff7828-79c7-11e6-8156-c38f528d4c1b.png)

@myclamm @hankim813 https://segment.atlassian.net/browse/INT-640