### PR TITLE
Add conversion of ISO-8601 dates to YYYY-MM-DD

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ var integration = require('@segment/analytics.js-integration');
 var foldl = require('@ndhoule/foldl');
 var each = require('@ndhoule/each');
 var reject = require('reject');
+var camel = require('to-camel-case');
+var is = require('is');
 var dateformat = require('dateformat');
 var Track = require('segmentio-facade').Track;
 
@@ -21,6 +23,7 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
   .option('agent', 'seg')
   .option('valueIdentifier', 'value')
   .option('initWithExistingTraits', false)
+  .option('traverse', false)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
@@ -85,17 +88,47 @@ FacebookPixel.prototype.page = function() {
 FacebookPixel.prototype.track = function(track) {
   var event = track.event();
   var revenue = formatRevenue(track.revenue());
-
   var payload = foldl(function(acc, val, key) {
     if (key === 'revenue') {
       acc.value = revenue;
       return acc;
     }
 
+    /**
+    * FB requires these date fields be formatted in a specific way.
+    * The specifications are non iso8601 compliant.
+    * https://developers.facebook.com/docs/marketing-api/dynamic-ads-for-travel/audience
+    * Therefore, we check if the property is one of these reserved fields.
+    * If so, we check if we have converted it to an iso date object already.
+    * If we have, we convert it again into Facebook's spec.
+    * If we have not, the user has likely passed in a date string that already
+    * adheres to FB's docs so we can just pass it through as is.
+    * @ccnixon
+    */
+
+    var dateFields = [
+      'checkinDate',
+      'checkoutDate',
+      'departingArrivalDate',
+      'departingDepartureDate',
+      'returningArrivalDate',
+      'returningDepartureDate',
+      'travelEnd',
+      'travelStart'
+    ];
+
+    if (dateFields.indexOf(camel(key)) >= 0) {
+      if (is.date(val)) {
+        val = val.toISOString().split('T')[0];
+        acc[key] = val;
+        return acc;
+      }
+    }
+
     acc[key] = val;
     return acc;
   }, {}, track.properties());
-
+  
   var standard = this.standardEvents(event);
   var legacy = this.legacyEvents(event);
 

--- a/package.json
+++ b/package.json
@@ -27,8 +27,10 @@
     "@ndhoule/foldl": "^2.0.1",
     "@segment/analytics.js-integration": "^3.1.0",
     "dateformat": "^1.0.12",
+    "is": "^3.2.1",
     "reject": "0.0.1",
-    "segmentio-facade": "^3.1.0"
+    "segmentio-facade": "^3.1.0",
+    "to-camel-case": "^1.0.0"
   },
   "devDependencies": {
     "@segment/analytics.js-core": "^3.0.0",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -14,7 +14,8 @@ describe('Facebook Pixel', function() {
     },
     standardEvents: {
       standardEvent: 'standard',
-      'booking completed': 'Purchase'
+      'booking completed': 'Purchase',
+      search: 'Search'
     },
     pixelId: '123123123',
     agent: 'test',
@@ -214,6 +215,28 @@ describe('Facebook Pixel', function() {
             currency: 'USD',
             value: '13.00',
             property: true
+          });
+        });
+        
+        describe('Dyanmic Ads for Travel date parsing', function() {
+          it('should correctly pass in iso8601 formatted date objects', function() {
+            analytics.track('search', {
+              checkin_date: '2017-07-01T20:03:46Z'
+            });
+
+            analytics.called(window.fbq, 'track', 'Search', {
+              checkin_date: '2017-07-01'
+            });
+          });
+
+          it('should pass through strings that we did not recognize as dates as-is', function() {
+            analytics.track('search', {
+              checkin_date: '2017-06-23T15:30:00GMT'
+            });
+
+            analytics.called(window.fbq, 'track', 'Search', {
+              checkin_date: '2017-06-23T15:30:00GMT'
+            });
           });
         });
       });

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -40,11 +40,14 @@ describe('Facebook Pixel', function() {
     });
   });
 
-  afterEach(function() {
-    analytics.restore();
-    analytics.reset();
-    facebookPixel.reset();
-    sandbox();
+  afterEach(function(done) {
+    analytics.waitForScripts(function() {
+      analytics.restore();
+      analytics.reset();
+      facebookPixel.reset();
+      sandbox();
+      done();
+    });
   });
 
   describe('before loading', function() {


### PR DESCRIPTION
This pr addresses an issue with converting iso formatted dates to a date formate FB will accept. Per their [docs](https://developers.facebook.com/docs/marketing-api/dynamic-ads-for-travel/audience) Facebook stipulates that dates for specific travel related fields can only be passed in the following format:

```
YYYYMMDD e.g. 20170623
YYYY-MM-DD e.g. 2017-06-23
YYYY-MM-DDThh:mmTZD e.g. 2017-06-23T15:30GMT
YYYY-MM-DDThh:mm:ssTZD e.g. 2017-06-23T15:30:00GMT
```
Previously, if you were passing us iso formatted dates as the values of those spec'd properties, we were converting them to date objects which was preventing them from being properly parsed by FB. 

Now, if we recognize that Facade has parsed a date string into a date object, we are going to return the original (ie non-utc-offset) version of the date, remove the time/utc offset, and send through the date as YYYY-MM-DD.

TODO: add docs explaining how to properly pass times/timezones for these fields.

Jira ticket: https://segment.atlassian.net/browse/EPD-2936