### PR TITLE
allow disable autoConfig

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -24,6 +24,7 @@ var FacebookPixel = module.exports = integration('Facebook Pixel')
   .option('valueIdentifier', 'value')
   .option('initWithExistingTraits', false)
   .option('traverse', false)
+  .option('disableAutoConfig', false)
   .mapping('standardEvents')
   .mapping('legacyEvents')
   .tag('<script src="//connect.facebook.net/en_US/fbevents.js">');
@@ -51,6 +52,9 @@ FacebookPixel.prototype.initialize = function() {
   window.fbq.version = '2.0';
   window.fbq.queue = [];
   this.load(this.ready);
+  if (this.options.disableAutoConfig) {
+    window.fbq('set', 'autoConfig', false, this.options.pixelId);
+  }
   if (this.options.initWithExistingTraits) {
     var traits = formatTraits(this.analytics);
     window.fbq('init', this.options.pixelId, traits);

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -82,6 +82,20 @@ describe('Facebook Pixel', function() {
       });
 
       before(function() {
+        options.disableAutoConfig = true;
+      });
+
+      after(function() {
+        options.disableAutoConfig = false;
+      });
+
+      it('should call set autoConfig if option disableAutoConfig is enabled', function () {
+        analytics.stub(window, 'fbq');
+        analytics.initialize();
+        analytics.called(window.fbq, 'set', 'autoConfig', false, options.pixelId);
+      });
+
+      before(function() {
         options.initWithExistingTraits = true;
       });
 


### PR DESCRIPTION
> The Facebook pixel will send button click and page metadata (such as data structured according to Opengraph or Schema.org formats) from your website to improve your ads delivery and measurement and automate your pixel setup - https://developers.facebook.com/docs/facebook-pixel/api-reference#automatic-configuration

So I added an option to disable it 👍 