### PR TITLE
fix(productListViewed): map productIds to content_ids param

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,3 +1,7 @@
+2.5.0 / 2018-06-22
+==================
+
+  * Map productIds to content_ids param instead of product category.
 
 2.4.2 / 2018-04-02
 ==================

--- a/lib/index.js
+++ b/lib/index.js
@@ -166,9 +166,32 @@ FacebookPixel.prototype.track = function(track) {
  */
 
 FacebookPixel.prototype.productListViewed = function(track) {
+  var contentType;
+  var contentIds = [];
+  var products = track.products();
+  
+  // First, check to see if a products array with productIds has been defined.
+  if (Array.isArray(products)) {
+    products.forEach(function(product) {
+      var productId = product.productId || product.product_id;
+      if (productId) {
+        contentIds.push(productId);
+      }
+    });
+  }
+
+  // If no products have been defined, fallback on legacy behavior.
+  // Facebook documents the content_type parameter decision here: https://developers.facebook.com/docs/facebook-pixel/api-reference
+  if (contentIds.length) {
+    contentType = 'product';
+  } else {
+    contentIds.push(track.category() || '');
+    contentType = 'product_group';
+  }
+
   window.fbq('track', 'ViewContent', {
-    content_ids: [track.category() || ''],
-    content_type: 'product_group'
+    content_ids: contentIds,
+    content_type: contentType
   });
 
   // fall through for mapped legacy conversions

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@segment/analytics.js-integration-facebook-pixel",
   "description": "The Facebook Pixel analytics.js integration.",
-  "version": "2.4.2",
+  "version": "2.5.0",
   "keywords": [
     "analytics.js",
     "analytics.js-integration",

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -250,11 +250,42 @@ describe('Facebook Pixel', function() {
       });
 
       describe('segment ecommerce => FB product audiences', function() {
-        it('Product List Viewed', function() {
-          analytics.track('Product List Viewed', { category: 'Games' });
-          analytics.called(window.fbq, 'track', 'ViewContent', {
-            content_ids: ['Games'],
-            content_type: 'product_group'
+        describe('Product List Viewed', function() {
+          it('Should map content_ids parameter to product_ids and content_type to "product" if possible', function() {
+            analytics.track('Product List Viewed', {
+              category: 'Games', products: [
+                {
+                  product_id: '507f1f77bcf86cd799439011',
+                  sku: '45790-32',
+                  name: 'Monopoly: 3rd Edition',
+                  price: 19,
+                  position: 1,
+                  category: 'Games',
+                  url: 'https://www.example.com/product/path',
+                  image_url: 'https://www.example.com/product/path.jpg'
+                },
+                {
+                  product_id: '505bd76785ebb509fc183733',
+                  sku: '46493-32',
+                  name: 'Uno Card Game',
+                  price: 3,
+                  position: 2,
+                  category: 'Games'
+                }
+              ]
+            });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['507f1f77bcf86cd799439011', '505bd76785ebb509fc183733'],
+              content_type: 'product'
+            });
+          });
+
+          it('Should fallback on mapping content_ids to the product category and content_type to "product_group"', function() {
+            analytics.track('Product List Viewed', { category: 'Games' });
+            analytics.called(window.fbq, 'track', 'ViewContent', {
+              content_ids: ['Games'],
+              content_type: 'product_group'
+            });
           });
         });
 


### PR DESCRIPTION
Previously we were mapping the product list category as the only member of an array to the FB pixel
content_ids param. FB expects this to be an array of productIds instead. This PR adds a change to
first check if the user has sent through a products array with productIds and if so, properly maps
them to the content_ids array. Otherwise, it simply falls back on the legacy behavior.

https://segment.atlassian.net/browse/PLATFORM-2400